### PR TITLE
Add `#inspect` and `.accessors`

### DIFF
--- a/lib/modelling.rb
+++ b/lib/modelling.rb
@@ -79,5 +79,13 @@ module Modelling
     end
     args.each { |name, value| send "#{name}=", value }
   end
+  
+  def inspect
+    hash = {}
+    self.class.accessors.each do |method_name|
+      hash[method_name] = send(method_name)
+    end
+    hash
+  end
 
 end

--- a/lib/modelling.rb
+++ b/lib/modelling.rb
@@ -32,6 +32,10 @@ module Modelling
     def members
       @members ||= {}
     end
+    
+    def accessors
+      @accessors ||= []
+    end
 
     private
 
@@ -55,6 +59,7 @@ module Modelling
     end
 
     def create_accessor(name)
+      accessors << name
       instance_eval { attr_accessor name }
     end
 

--- a/spec/modelling_spec.rb
+++ b/spec/modelling_spec.rb
@@ -130,6 +130,12 @@ describe Modelling do
     User.accessors.should include :name, :age
   end
   
+  specify 'provides a Hash of attributes and values through inspect' do
+    User.new.inspect.key?(:name).should be_true
+    User.new.inspect.key?(:age).should be_true
+    User.new(:name => "Joe").inspect[:name].should eq "Joe"
+  end
+
   context 'inheritence' do
     let(:car) { Car.new }
     let(:super_car) { SuperCar.new }

--- a/spec/modelling_spec.rb
+++ b/spec/modelling_spec.rb
@@ -125,7 +125,11 @@ describe Modelling do
   it 'doesnt fail when lambdas with no args are used' do
     LambdaTest.new.lambda.should  eq 'boo'
   end
-
+  
+  specify 'tracks list of accessors' do
+    User.accessors.should include :name, :age
+  end
+  
   context 'inheritence' do
     let(:car) { Car.new }
     let(:super_car) { SuperCar.new }


### PR DESCRIPTION
Hello, I wanted to get something hash-like back from `MyModel#inspect`. Previously, `#inspect` just delegated to `#to_s`, which I think is the default behaviour for `Kernal#to_s`. This is now way more bettererer, returning a hash of method names and values so that I can, you know, inspect stuff.

```
>> User.new(:name => "Joe").inspect
=> { :name => "Joe" }
```
