### PR TITLE
Fix circular references

### DIFF
--- a/lib/modelling.rb
+++ b/lib/modelling.rb
@@ -80,12 +80,16 @@ module Modelling
     args.each { |name, value| send "#{name}=", value }
   end
   
-  def inspect
+  def attributes
     hash = {}
     self.class.accessors.each do |method_name|
       hash[method_name] = send(method_name)
     end
     hash
+  end
+  
+  def inspect
+    attributes.to_s
   end
 
 end

--- a/lib/modelling.rb
+++ b/lib/modelling.rb
@@ -89,7 +89,22 @@ module Modelling
   end
   
   def inspect
-    attributes.to_s
+    attributes_as_nice_string = attributes.collect { |name, value|
+      "#{name}: #{attribute_for_inspect(value)}"
+    }.compact.join(", ")
+    "#<#{self.class} #{attributes_as_nice_string}>"
   end
-
+  
+  def attribute_for_inspect(value)
+    if value.is_a?(String) && value.length > 50
+      "#{value[0..50]}...".inspect
+    elsif value.is_a?(Date) || value.is_a?(Time)
+      %("#{value.to_s(:db)}")
+    elsif value.class.included_modules.include?(Modelling)
+      "#<#{value.class.to_s}>"
+    else
+      value.inspect
+    end
+  end
+  
 end

--- a/spec/modelling_spec.rb
+++ b/spec/modelling_spec.rb
@@ -130,12 +130,17 @@ describe Modelling do
     User.accessors.should include :name, :age
   end
   
-  specify 'provides a Hash of attributes and values through inspect' do
-    User.new.inspect.key?(:name).should be_true
-    User.new.inspect.key?(:age).should be_true
-    User.new(:name => "Joe").inspect[:name].should eq "Joe"
+  specify 'provides a Hash of attributes and values' do
+    User.new.attributes.key?(:name).should be_true
+    User.new.attributes.key?(:age).should be_true
+    User.new(:name => "Joe").attributes[:name].should eq "Joe"
   end
-
+  
+  specify 'converts the attributes hash to a string for inspect' do
+    u = User.new(:name => "Joe")
+    u.inspect.should == u.attributes.to_s
+  end
+  
   context 'inheritence' do
     let(:car) { Car.new }
     let(:super_car) { SuperCar.new }


### PR DESCRIPTION
Made the `#inspect` output look more like other ruby objects ("#<ModelName key:val, key:val>"), and avoid stack level too deep errors by only naming (rather than inspecting) values that are `Modelling` objects.

This is not perfect (nested inspects for non-circular model references should be fine), but the end result is still monumentally better than `#inspect` simply returning the model name.

Actually tested in the reference app too :)
